### PR TITLE
UI improvements for transfer requests view

### DIFF
--- a/Shared/Backend/Remote.swift
+++ b/Shared/Backend/Remote.swift
@@ -35,7 +35,22 @@ struct ResolvedHost {
     let port: Int
 }
 
-class Remote {
+protocol RemoteProtocol {
+    
+    var peer: Peer { get }
+    var transfers: CurrentValueSubject<Array<TransferOp>, Never> { get }
+    var state: RemoteState { get }
+    
+    func ping() async throws
+    
+    func requestTransfer(url: URL) async throws
+    
+    func statePublisher() -> AnyPublisher<RemoteState, Never>
+    
+}
+
+
+class Remote: RemoteProtocol, ObservableObject {
     
     private let statemachine: StateMachine
     private var stateCancellable: AnyCancellable?
@@ -49,7 +64,11 @@ class Remote {
                 }
             }
         }
-      }  
+    }
+    
+    func statePublisher() -> AnyPublisher<RemoteState, Never> {
+        return $state.eraseToAnyPublisher()
+    }
     
     var peer: Peer
     

--- a/Shared/Backend/Remote.swift
+++ b/Shared/Backend/Remote.swift
@@ -395,7 +395,7 @@ class Remote: RemoteProtocol, ObservableObject {
         }
     }
         
-    func startTransfer(transferOp: TransferFromRemote) async throws {
+    func startTransfer(transferOp: TransferFromRemote, downloader: TransferDownloader) async throws {
         
         guard transferOp.state == .requested else {
             throw TransferOpError.invalidStateToStartTransfer
@@ -414,8 +414,6 @@ class Remote: RemoteProtocol, ObservableObject {
             $0.ident = auth.identity
             $0.readableName = auth.networkConfig.hostname
         })
-                
-        let downloader = try TransferDownloader(topDirBasenames: transferOp.topDirBasenames, progress: transferOp.progress)
         
         transferOp.localSaveUrls = downloader.savePaths
         

--- a/Shared/Backend/Remote.swift
+++ b/Shared/Backend/Remote.swift
@@ -415,7 +415,7 @@ class Remote: RemoteProtocol, ObservableObject {
             $0.readableName = auth.networkConfig.hostname
         })
         
-        transferOp.localSaveUrls = downloader.savePaths
+        transferOp.localSaveUrls = downloader.saveURLs
         
         let response = client.startTransfer(opInfo)
         

--- a/Shared/Backend/TransferOp.swift
+++ b/Shared/Backend/TransferOp.swift
@@ -161,7 +161,17 @@ class TransferFromRemote: TransferOp {
         self.progress = .init(totalBytesCount: Int(size))
         
     }
-        
+    
+    func checkIfWillOverwrite() -> Bool {
+        switch transferDownloader {
+        case .success(let downloader):
+            return downloader.checkIfWillOverwrite()
+        case .failure(_):
+            // If the downloader failed to instantiate, won't overwrite files because the download can't be started.
+            return false
+        }
+    }
+    
     func accept() async throws {
         if state == .requested {
             do {

--- a/Shared/TransferDownloader.swift
+++ b/Shared/TransferDownloader.swift
@@ -61,6 +61,15 @@ class TransferDownloader {
         return saveURLs
     }()
     
+    func checkIfWillOverwrite() -> Bool {
+        for url in saveURLs {
+            // Check if path already exists
+            if fileManager.fileExists(atPath: url.path) {
+                return true
+            }
+        }
+        
+        return false;
     }
     
     func handleChunk(chunk: FileChunk) throws {

--- a/Shared/TransferDownloader.swift
+++ b/Shared/TransferDownloader.swift
@@ -95,7 +95,7 @@ class TransferDownloader {
             // The first chunk should have timestamp
             if chunk.hasTime {
                 let timestamp = NSDate.from(time: chunk.time)
-                try FileManager.default.setAttributes([.modificationDate: timestamp], ofItemAtPath: fileUrl.path)
+                try fileManager.setAttributes([.modificationDate: timestamp], ofItemAtPath: fileUrl.path)
             }
         } else {
             // Read the current modification date
@@ -105,7 +105,7 @@ class TransferDownloader {
             try chunk.chunk.append(fileURL: fileUrl)
 
             // Keep the modification date
-            try FileManager.default.setAttributes([.modificationDate: timestamp as Any], ofItemAtPath: fileUrl.path)
+            try fileManager.setAttributes([.modificationDate: timestamp as Any], ofItemAtPath: fileUrl.path)
         }
     }
 
@@ -120,7 +120,7 @@ class TransferDownloader {
         
         let newFolderPath = try self.sanitizeRelativePath(relativePath: chunk.relativePath)
         
-        try FileManager.default.createDirectory(at: newFolderPath, withIntermediateDirectories: true, attributes: [.modificationDate: timestamp])
+        try fileManager.createDirectory(at: newFolderPath, withIntermediateDirectories: true, attributes: [.modificationDate: timestamp])
     }
     
     /// Make sure that the relative path doesn't go outside of the save directory and starts with a path component that is in

--- a/Shared/TransferDownloader.swift
+++ b/Shared/TransferDownloader.swift
@@ -49,16 +49,18 @@ class TransferDownloader {
     }
     
     /// The local paths the topDirBasenames will be downloaded to. This is computed by computing the local save path for each sanitized topDirBaseName given the self.saveDirectory
-    var savePaths: [URL] {
-        let savePaths = try? topDirBasenames.map { baseName in
+    lazy var saveURLs: [URL] = {
+        let saveURLs = try? topDirBasenames.map { baseName in
             try sanitizeRelativePath(relativePath: baseName).absoluteURL
         }
         
-        guard let savePaths = savePaths else {
+        guard let saveURLs = saveURLs else {
             return []
         }
         
-        return savePaths
+        return saveURLs
+    }()
+    
     }
     
     func handleChunk(chunk: FileChunk) throws {

--- a/Shared/Views/ConfirmationView.swift
+++ b/Shared/Views/ConfirmationView.swift
@@ -1,0 +1,71 @@
+//
+//  ConfirmationView.swift
+//  warpinator-project
+//
+//  Created by Emanuel on 10/03/2024.
+//
+
+import SwiftUI
+
+struct ConfirmDestructiveActionModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    
+    let title: String
+    //    let message: String
+    
+    let confirmText = "Overwrite"
+    let cancelText = "Cancel"
+    
+    let onConfirm: () -> Void
+    let onCancel: (() -> Void)?
+    
+    
+    func body(content: Content) -> some View {
+#if os(macOS)
+        content.popover(isPresented: $isPresented) {
+            popoverView
+        }
+#else
+        content.actionSheet(isPresented: $isPresented) {
+            actionSheet
+        }
+#endif
+    }
+    
+#if os(macOS)
+    var popoverView: some View {
+        VStack {
+            Text(title)
+            
+            HStack {
+                Button(cancelText) {
+                    self.isPresented = false
+                    if let onCancel = self.onCancel {
+                        onCancel()
+                    }
+                }
+                Button(confirmText) {
+                    self.isPresented = false
+                    self.onConfirm()
+                }
+            }
+        }.padding()
+    }
+#else
+    var actionSheet: ActionSheet {
+        ActionSheet(title: Text(title), message: nil, buttons: [
+            .cancel(Text(cancelText), action: onCancel),
+            .destructive(Text(confirmText), action: onConfirm)
+        ])
+    }
+#endif
+    
+}
+
+extension View {
+    func overwriteConfirmation(isPresented: Binding<Bool>, title: String, onConfirm: @escaping () -> Void, onCancel: (() -> Void)?=nil) -> some View {
+        self.modifier(ConfirmDestructiveActionModifier(
+            isPresented: isPresented, title: title, onConfirm: onConfirm, onCancel: onCancel)
+        )
+    }
+}

--- a/Shared/Views/RemoteDetailView.swift
+++ b/Shared/Views/RemoteDetailView.swift
@@ -194,3 +194,44 @@ extension RemoteDetailView {
         }
     }
 }
+
+#if DEBUG
+
+class DummyRemote: RemoteProtocol {
+    var peer: Peer = MDNSPeer(domain: "mint.local", type: "real", name: "Warpinator mint", txtRecord: .init())
+    
+    var transfers: CurrentValueSubject<Array<TransferOp>, Never> = .init([DummyTransferOp(), DummyTransferOp(), DummyTransferOp()])
+    
+    var state: RemoteState = .online
+    
+    func ping() async throws {
+        
+    }
+    
+    func requestTransfer(url: URL) async throws {
+        
+    }
+    
+    func statePublisher() -> AnyPublisher<RemoteState, Never> {
+        CurrentValueSubject<RemoteState, Never>.init(.online).eraseToAnyPublisher()
+    }
+    
+    
+}
+
+extension RemoteDetailView.ViewModel {
+    static var preview: Self {
+        let dummyRemote = DummyRemote()
+        
+        return RemoteDetailView.ViewModel(remote: dummyRemote) as! Self
+    }
+}
+
+struct RemoteDetailViewPreview: PreviewProvider {
+    static var previews: some View {
+        RemoteDetailView(viewModel: RemoteDetailView.ViewModel.preview, showingSheet: false)
+    }
+}
+
+
+#endif

--- a/Shared/Views/RemoteDetailView.swift
+++ b/Shared/Views/RemoteDetailView.swift
@@ -154,7 +154,7 @@ extension RemoteDetailView {
         @Published
         var state: String = ""
         
-        private let remote: Remote
+        private let remote: RemoteProtocol
         
         private var tokens: Set<AnyCancellable> = .init()
         
@@ -170,7 +170,7 @@ extension RemoteDetailView {
             }
         }
         
-        init(remote: Remote) {
+        init(remote: RemoteProtocol) {
             self.remote = remote
             
             self.title = remote.peer.hostName
@@ -186,7 +186,7 @@ extension RemoteDetailView {
             }.store(in: &tokens)
             
             Task {
-                remote.$state.receive(on: DispatchQueue.main).sink { state in
+                remote.statePublisher().receive(on: DispatchQueue.main).sink { state in
                     self.state = "\(state.description)"
                 }.store(in: &tokens)
             }

--- a/Shared/Views/TransferOpView.swift
+++ b/Shared/Views/TransferOpView.swift
@@ -14,6 +14,8 @@ import Combine
 import AppKit
 #endif
 
+import UniformTypeIdentifiers
+
 extension Direction {
     var imageSystemName: String {
         switch self {
@@ -34,7 +36,7 @@ struct TransferOpView: View {
         HStack {
             Image(systemName: viewModel.directionImageSystemName)
             #if canImport(AppKit)
-            Image(nsImage: NSWorkspace.shared.icon(for: (.init(filenameExtension: "pdf") ?? .data)))
+            Image(nsImage: NSWorkspace.shared.icon(for: viewModel.uttype))
             #endif
 
             Text(viewModel.title)
@@ -155,6 +157,12 @@ extension TransferOpView {
         
         var availableActions: TransferOpAvailableActions {
             transferOp.availableActions
+        }
+        
+        var uttype: UTType {
+            let defaultType: UTType = transferOp.count == 1 ? .data : .folder
+            
+            return UTType.init(mimeType: transferOp.mimeType) ?? defaultType
         }
         
         func accept() {

--- a/Shared/Views/TransferOpView.swift
+++ b/Shared/Views/TransferOpView.swift
@@ -243,3 +243,54 @@ extension TransferOpView {
         }
     }
 }
+
+#if DEBUG
+
+class DummyTransferOp: TransferOp {
+    var direction: Direction = .download
+    
+    var localTimestamp: Date = .init()
+    
+    var timestamp: UInt64 = DispatchTime.now().rawValue
+    
+    var _state: MutableObservableValue<TransferOpState> = .init(.requested)
+    
+    var title: String = "warpinator-project.app.dSYM.zip"
+    
+    var mimeType: String = "archive/zip"
+    
+    var size: UInt64 = 1002
+    
+    var count: UInt64 = 1
+    
+    var topDirBasenames: [String] = ["image.png"]
+    
+    func cancel() async {
+        
+    }
+    
+    func remove() {
+        
+    }
+    
+    var progress: TransferOpMetrics = .init(totalBytesCount: 1000)
+    
+    
+}
+
+extension TransferOpView.ViewModel {
+    static var preview: Self {
+        let dummyTransferOp = DummyTransferOp()
+        
+        return TransferOpView.ViewModel(transferOp: dummyTransferOp) as! Self
+    }
+}
+
+struct TransferOpView_Previews: PreviewProvider {
+    static var previews: some View {
+        TransferOpView(viewModel: TransferOpView.ViewModel.preview).environmentObject(LayoutInfo())
+    }
+}
+
+
+#endif

--- a/Shared/Views/TransferOpView.swift
+++ b/Shared/Views/TransferOpView.swift
@@ -236,6 +236,14 @@ extension TransferOpView {
             }
         }
         
+        func checkIfWillOverwrite() -> Bool {
+            guard let transferOp = transferOp as? TransferFromRemote else {
+                preconditionFailure()
+            }
+
+            return transferOp.checkIfWillOverwrite()
+        }
+        
         func accept() {
             
             guard let transferOp = transferOp as? TransferFromRemote else {

--- a/Shared/Views/TransferOpView.swift
+++ b/Shared/Views/TransferOpView.swift
@@ -18,9 +18,9 @@ extension Direction {
     var imageSystemName: String {
         switch self {
         case .upload:
-            return "chevron.up"
+            return "arrow.up.to.line.alt"
         case .download:
-            return "chevron.down"
+            return "arrow.down.to.line.alt"
         }
     }
 }

--- a/Shared/Views/TransferOpView.swift
+++ b/Shared/Views/TransferOpView.swift
@@ -32,27 +32,68 @@ struct TransferOpView: View {
     @ObservedObject
     var viewModel: ViewModel
 
+    @EnvironmentObject
+    var layoutInfo: LayoutInfo
+    
     var body: some View {
+        if layoutInfo.width < 500 {
+            narrowView
+        } else {
+            wideView
+        }
+    }
+    
+    var wideView: some View {
         HStack {
             Image(systemName: viewModel.directionImageSystemName).frame(width: 20, alignment: .center)
             
             Image(systemName: viewModel.fileIconSystemName).frame(width: 20, alignment: .center)
             
+            Text(viewModel.title).lineLimit(1).truncationMode(.middle)
+                .frame(minWidth: 200, alignment: .leading)
 
-            Text(viewModel.title)
-                .frame(maxWidth: 250, alignment: .leading)
-
-            Text(viewModel.size).frame(maxWidth: 50, alignment: .leading)
+            Text(viewModel.size).frame(minWidth: 80, alignment: .leading)
 
             StatusView(state: viewModel.state, progress: viewModel.progressMetrics)
+                .frame(width: 85)
 
             Spacer()
 
             actionButtons
 
         }
+        #if !os(macOS)
+        .frame(minHeight: 40)
+        #endif
     }
     
+    var narrowView: some View {
+        HStack {
+            HStack {
+                Image(systemName: viewModel.directionImageSystemName)
+                
+                Image(systemName: viewModel.fileIconSystemName)
+            }
+            
+            VStack {
+                HStack {
+                    Text(viewModel.title).bold().lineLimit(1).truncationMode(.middle)
+                    
+                    Spacer()
+                }.padding(.bottom, 2.0).frame(alignment: .leading)
+                
+                HStack {
+                    Text(viewModel.size).frame(minWidth: 40, alignment: .leading)
+                    
+                    StatusView(state: viewModel.state, progress: viewModel.progressMetrics).frame(alignment: .center)
+                    
+                    Spacer()
+                }
+            }
+            .padding()
+            actionButtons
+        }
+    }
     var actionButtons: some View {
         switch(viewModel.availableActions) {
         case .acceptOrCancel:
@@ -69,7 +110,7 @@ struct TransferOpView: View {
                     Image(systemName: "xmark")
                 }.buttonStyle(.borderless)
             })
-
+            
         case .cancel:
             return AnyView(
                 Button {
@@ -93,16 +134,17 @@ struct TransferOpView: View {
                 } label: {
                     Image(systemName: "folder")
                 }.buttonStyle(.borderless)
-
+                
                 Button {
                     viewModel.remove()
                 } label: {
                     Image(systemName: "minus")
                 }.buttonStyle(.borderless)
-
+                
             })
         }
     }
+    
 }
 
 struct StatusView: View {

--- a/Shared/Views/TransferOpView.swift
+++ b/Shared/Views/TransferOpView.swift
@@ -34,10 +34,10 @@ struct TransferOpView: View {
 
     var body: some View {
         HStack {
-            Image(systemName: viewModel.directionImageSystemName)
-            #if canImport(AppKit)
-            Image(nsImage: NSWorkspace.shared.icon(for: viewModel.uttype))
-            #endif
+            Image(systemName: viewModel.directionImageSystemName).frame(width: 20, alignment: .center)
+            
+            Image(systemName: viewModel.fileIconSystemName).frame(width: 20, alignment: .center)
+            
 
             Text(viewModel.title)
                 .frame(maxWidth: 250, alignment: .leading)
@@ -163,6 +163,35 @@ extension TransferOpView {
             let defaultType: UTType = transferOp.count == 1 ? .data : .folder
             
             return UTType.init(mimeType: transferOp.mimeType) ?? defaultType
+        }
+        
+        var fileIconSystemName: String {
+            /** System icon name to represent the file transfer */
+            
+            if transferOp.count == 1 {
+                
+                print("UTType: \(self.uttype)")
+                
+                if self.uttype.conforms(to: .image) {
+                    return "photo"
+                } else if self.uttype.conforms(to: .archive) {
+                    return "doc.zipper"
+                } else if self.uttype.conforms(to: .plainText) {
+                    return "doc.plaintext"
+                } else if self.uttype.conforms(to: .text) {
+                    return "doc.text"
+                } else if self.uttype.conforms(to: .content) {
+                    return "doc.fill"
+                } else {
+                    return "doc"
+                }
+            } else {
+                if transferOp.mimeType.contains("directory") {
+                    return "folder"
+                } else {
+                    return "doc.on.doc"
+                }
+            }
         }
         
         func accept() {

--- a/Shared/Views/TransferOpView.swift
+++ b/Shared/Views/TransferOpView.swift
@@ -35,6 +35,9 @@ struct TransferOpView: View {
     @EnvironmentObject
     var layoutInfo: LayoutInfo
     
+    @State
+    var showConfirmPopover = false
+
     var body: some View {
         if layoutInfo.width < 500 {
             narrowView
@@ -99,10 +102,21 @@ struct TransferOpView: View {
         case .acceptOrCancel:
             return AnyView(HStack {
                 Button {
-                    viewModel.accept()
+                    if viewModel.checkIfWillOverwrite() {
+                        self.showConfirmPopover = true
+                    } else {
+                        viewModel.accept()
+                    }
                 } label: {
                     Image(systemName: "checkmark")
                 }.buttonStyle(.borderless)
+                    .overwriteConfirmation(
+                    isPresented: $showConfirmPopover,
+                    title: "Accepting this transfer will overwrite files. Are you sure?",
+                    onConfirm: {
+                        viewModel.accept()
+                    }
+                )
                 
                 Button {
                     viewModel.cancel()


### PR DESCRIPTION
This pull request improves the UI of accepting a transfer request by:

- Show confirmation before starting transfer that will overwrite files (fixes #12)
- Fix file icon that is shown (fixes #13)
  - By switching to SF symbol based icons which also work on iOS
- Make incoming transfer view responsive, by showing the information on two lines for narrow window sizes
- Added a preview view in Xcode for TransferOp, and the remote detailview for easier UI adjustment