### PR TITLE
Show received file location on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ There are two ways to run the app:
     - [X] Single file
     - [ ] Single folder
     - [ ] Multiple files/folders
-- [ ] Show received file location
+- [X] Show received file location
     - [X] on macOS
-    - [ ] on iOS (they can be found in the files app)
+    - [X] on iOS
 - [ ] Settings view (currently macOS only)
     - [X] Set groupcode

--- a/Shared/Views/TransferOpView.swift
+++ b/Shared/Views/TransferOpView.swift
@@ -10,10 +10,6 @@ import SwiftUI
 
 import Combine
 
-#if canImport(AppKit)
-import AppKit
-#endif
-
 import UniformTypeIdentifiers
 
 extension String: Identifiable {
@@ -369,12 +365,7 @@ extension TransferOpView {
             print("localurls:")
             print(transferOp.localSaveUrls)
             
-            #if os(macOS)
-            NSWorkspace.shared.activateFileViewerSelecting(transferOp.localSaveUrls)
-            #endif
-            
-            //TODO: Show file location on iOS
-            
+            openFilesApp(urls: transferOp.localSaveUrls)
         }
 
         var bag: Set<AnyCancellable> = .init()
@@ -388,6 +379,7 @@ extension TransferOpView {
         }
     }
 }
+
 
 #if DEBUG
 

--- a/Shared/lib/Utils.swift
+++ b/Shared/lib/Utils.swift
@@ -7,6 +7,14 @@
 
 import Foundation
 
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+
+
 extension Data {
     var bytes: [UInt8] {
         return [UInt8](self)
@@ -42,3 +50,39 @@ func getDocumentsDirectory() throws -> URL {
 
         return rootFolderURL
     }
+
+
+func openFilesApp(urls: [URL]) {
+#if os(macOS)
+    // On macOS, a finder window selecting all of the urls can be opened:
+    NSWorkspace.shared.activateFileViewerSelecting(urls)
+#else
+    
+    // On iOS, you can only open the files app in a specific directory, but not highlight multiple files:
+    var url: URL = urls[0]
+
+    // Find the parent directory of the first file
+    if !url.isDirectory {
+        url = url.deletingLastPathComponent()
+    }
+                
+    guard let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true) else {
+        return
+    }
+
+    // Open the files app pointing at the directory
+    components.scheme = "shareddocuments"
+
+    if let sharedDocument = components.url {
+        print("sharedDocument: \(sharedDocument)")
+        
+        UIApplication.shared.open(sharedDocument)
+    }
+#endif
+}
+
+extension URL {
+    var isDirectory: Bool {
+       (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+    }
+}


### PR DESCRIPTION
- Extracts the implementation for showing files into a utility method: `openFilesApp(urls: [URL])`.
- Adds an implementation for iOS that opens the files app.

Fixes #7.