### PR TITLE
Fix cancel button should dismiss confirmation dialog

### DIFF
--- a/Shared/Views/ConfirmationView.swift
+++ b/Shared/Views/ConfirmationView.swift
@@ -17,8 +17,7 @@ struct ConfirmDestructiveActionModifier: ViewModifier {
     let cancelText = "Cancel"
     
     let onConfirm: () -> Void
-    let onCancel: (() -> Void)?
-    
+    let onCancel: () -> Void
     
     func body(content: Content) -> some View {
 #if os(macOS)
@@ -40,9 +39,7 @@ struct ConfirmDestructiveActionModifier: ViewModifier {
             HStack {
                 Button(cancelText) {
                     self.isPresented = false
-                    if let onCancel = self.onCancel {
-                        onCancel()
-                    }
+                    self.onCancel()
                 }
                 Button(confirmText) {
                     self.isPresented = false
@@ -63,7 +60,7 @@ struct ConfirmDestructiveActionModifier: ViewModifier {
 }
 
 extension View {
-    func overwriteConfirmation(isPresented: Binding<Bool>, title: String, onConfirm: @escaping () -> Void, onCancel: (() -> Void)?=nil) -> some View {
+    func overwriteConfirmation(isPresented: Binding<Bool>, title: String, onConfirm: @escaping () -> Void, onCancel: @escaping () -> Void={}) -> some View {
         self.modifier(ConfirmDestructiveActionModifier(
             isPresented: isPresented, title: title, onConfirm: onConfirm, onCancel: onCancel)
         )


### PR DESCRIPTION
Previously, `onCancel` was `nil` by default for the `overwriteConfirmation` view modifier. For the iOS implementation which uses `ActionSheet`, setting a `nil` action for the `.cancel` button disables the button.

This PR changes the `onCancel` action of `overwriteConfirmation`  to be an empty closure `{}` by default, which enables the cancel button. The dismiss logic is already built into the ActionSheet `.cancel` button as long as the `action` of the button is not nil.

Fixes #19.