### PR TITLE
Fix: should reconnect on remote port change

### DIFF
--- a/Shared/Backend/Remote.swift
+++ b/Shared/Backend/Remote.swift
@@ -187,6 +187,9 @@ class Remote: RemoteProtocol, ObservableObject {
 
     @MainActor
     func mdnsDiscovered(peer: Peer) {
+        // Peer came online and might have changed port.
+        self.peer = peer
+        
         statemachine.tryEvent(.peerCameOnline)
     }
     

--- a/Shared/Backend/RemoteLifeCycleStateMachine.swift
+++ b/Shared/Backend/RemoteLifeCycleStateMachine.swift
@@ -59,9 +59,9 @@ extension StateMachine {
             print("Statemachine transition: \(self.state) -> \(state) for event: \(event)")
             
             self.state = state
+        } else {
+            print("Statemachine ignored transition: \(self.state) -> \(state) for event: \(event)")
         }
-        
-        print("Statemachine ignored transition: \(self.state) -> \(state) for event: \(event)")
     }
 }
 


### PR DESCRIPTION
Fixes #22.

This PR addresses an issue where changes in the remote's port were not properly handled, leading to potential connection issues. Previously, a change in the peer's hostname or authentication port during rediscovery was ignored, and which caused reconnection attempts to fail.

Changes:

- The stored Peer details (hostname and auth port) are updated on upon rediscovery.

For further experimentation: should the state machine also be updated to retry when the peer comes online? This doesn't seem necessary as it will already retry after failure or when a peer comes online after having been offline.