### PR TITLE
Implement WarpManager to handle starting/restarting/resuming WarpBackend

### DIFF
--- a/Shared/Backend/BonjourDiscovery.swift
+++ b/Shared/Backend/BonjourDiscovery.swift
@@ -130,6 +130,17 @@ class BonjourDiscovery: PeerDiscovery {
         onRemotesChanged(.mdnsOfflineAll)
     }
     
+    func cancelBonjour() {
+        listener?.cancel()
+        listener?.service = nil
+        
+        browser?.cancel()
+        
+        Task.detached {
+            self.onRemotesChanged(.mdnsOfflineAll)
+        }
+    }
+    
     func restartBonjour() {
         setupBrowser()
         refreshService()
@@ -299,5 +310,12 @@ class BonjourDiscovery: PeerDiscovery {
                                                   type: "_warpinator._tcp",
                                                   txtRecord: txtRecord)
         }
+    }
+    
+    deinit {
+        print("BonjourDiscovery.deinit() called")
+        
+        listener?.cancel()
+        browser?.cancel()
     }
 }

--- a/Shared/Backend/WarpManager.swift
+++ b/Shared/Backend/WarpManager.swift
@@ -35,10 +35,6 @@ extension WarpError: LocalizedError {
     }
 }
 
-extension String: Error {
-    
-}
-
 protocol WarpObserverDelegate: AnyObject {
     func stateDidUpdate(newState: WarpState)
     

--- a/Shared/Backend/WarpManager.swift
+++ b/Shared/Backend/WarpManager.swift
@@ -18,7 +18,6 @@ enum WarpState {
     
     case notInitialized
     case running
-    case stopped
     case failure(_ error: WarpError)
     case restarting
 }
@@ -54,7 +53,6 @@ actor WarpManager {
         case idle
         case starting
         case running
-        case stopping
         case restarting
         case suspended
     }
@@ -156,23 +154,6 @@ actor WarpManager {
         
         self.warpState = .running
         self.managerState = .running
-    }
-    
-    func stop() {
-        
-        guard managerState == .running || managerState == .restarting else { return }
-        
-        managerState = .stopping
-        
-        
-        self.warp?.stop()
-        warpState = .stopped
-        
-        managerState = .idle
-        
-        // Needed for iOS
-        endBackgroundTask()
-        
     }
     
     func resetupListener() {

--- a/Shared/Backend/WarpManager.swift
+++ b/Shared/Backend/WarpManager.swift
@@ -208,7 +208,18 @@ actor WarpManager {
         // Needed for iOS
         endBackgroundTask()
         
-        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        do {
+            try await Task.sleep(nanoseconds: 1_000_000_000)
+        } catch {
+            // Don't call start on cancellation
+            return
+        }
+        
+        guard managerState == .restarting else {
+            // The state was modified outside of restart()
+            // This can happen because actors still suspend and allow other methods to run at await suspension points (.i.e. Task.sleep)
+            return
+        }
         
         await start()
     }

--- a/Shared/Backend/WarpManager.swift
+++ b/Shared/Backend/WarpManager.swift
@@ -1,0 +1,265 @@
+//
+//  WarpManager.swift
+//  warpinator-project
+//
+//  Created by Emanuel on 14/03/2024.
+//
+
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+import os
+
+enum WarpState {
+    case unableToDiscoverSelf
+    
+    case notInitialized
+    case running
+    case stopped
+    case failure(_ error: WarpError)
+    case restarting
+}
+
+enum WarpError: Error {
+    case failedToStart(Error)
+}
+
+extension WarpError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .failedToStart(let error):
+            return NSLocalizedString("Failed to start server: \(error)", comment: "Failed to start")
+        }
+    }
+}
+
+extension String: Error {
+    
+}
+
+protocol WarpObserverDelegate: AnyObject {
+    func stateDidUpdate(newState: WarpState)
+    
+    // Delegate is called by WarpManager after starting to pass the RemoteRegistrationObserver object to the delegate.
+    func warpStarted(remoteRegistration: RemoteRegistrationObserver)
+}
+
+
+actor WarpManager {
+    
+    enum ManagerState {
+        case idle
+        case starting
+        case running
+        case stopping
+        case restarting
+        case suspended
+    }
+   
+    // State that is used to track the lifecycle of the Warp instance
+    private var managerState: ManagerState = .idle
+    
+    private let settings: WarpSettings = WarpSetingsUserDefaults.shared
+    
+#if canImport(UIKit)
+    private var backgroundTaskId: UIBackgroundTaskIdentifier = .invalid
+#endif
+    
+    // State that is shown in the UI, and reflects internal errors
+    var warpState: WarpState = .notInitialized {
+        didSet {
+            let warpState = self.warpState
+            
+            print("WarpManager warpState didset: \(managerState)")
+            
+            guard let delegate = self.delegate else { return }
+            
+            Task {
+                await MainActor.run {
+                    delegate.stateDidUpdate(newState: warpState)
+                }
+            }
+        }
+    }
+    
+    var warp: WarpBackend? =  nil
+    
+    var delegate: WarpObserverDelegate?
+    
+    private func waitForLocalNetworkPermission() async {
+        var granted = false
+        
+        var timeout = 2.0
+        
+        while !granted {
+            granted = await requestLocalNetworkPermissionAsync(timeout: timeout)
+            
+            if !granted {
+                warpState = .unableToDiscoverSelf
+            }
+            
+            timeout = 5.0
+        }
+    }
+    
+    private func initialize() async {
+        
+        // Not needed on macOS:
+#if !os(macOS)
+        await self.waitForLocalNetworkPermission()
+#endif
+        
+        self.warp = WarpBackend()
+        
+        self.settings.addOnConnectionSettingsChangedCallback {
+            Task.detached {
+                await self.onConnectionSettingsChanged()
+            }
+        }
+        
+    }
+    
+    func start() async {
+        guard managerState == .idle || managerState == .restarting else {
+            return
+        }
+        
+        managerState = .starting
+        
+        if self.warp == nil {
+            await self.initialize()
+        }
+        
+        guard let warp = warp else {
+            preconditionFailure()
+        }
+        
+        do {
+            try await warp.start()
+            
+            await startBackgroundTask()
+        } catch {
+            self.warpState = .failure(.failedToStart(error))
+            self.managerState = .idle
+            
+            return
+        }
+        
+        if let delegate = delegate {
+            await MainActor.run {
+                delegate.warpStarted(remoteRegistration: warp.remoteRegistration)
+            }
+        }
+        
+        self.warpState = .running
+        self.managerState = .running
+    }
+    
+    func stop() {
+        
+        guard managerState == .running || managerState == .restarting else { return }
+        
+        managerState = .stopping
+        
+        
+        self.warp?.stop()
+        warpState = .stopped
+        
+        managerState = .idle
+        
+        // Needed for iOS
+        endBackgroundTask()
+        
+    }
+    
+    func resetupListener() {
+        self.warp?.resetupListener()
+    }
+    
+    func background() {
+        // Don't need to handle this, as using the startBackgroundTask experiation handler
+    }
+    
+    func shouldSuspend() {
+        
+        os_log("Called WarpManager.shouldSuspend()")
+        
+        managerState = .suspended
+        
+        self.endBackgroundTask()
+    }
+    
+    func pause() {
+        self.warp?.pause()
+    }
+    
+    func resume() async {
+        if managerState == .running {
+            // Just refresh bonjour
+            self.warp?.resume()
+        } else {
+            // e.g. when backgrounded, or for some other reason wasn't running
+            await restart()
+        }
+    }
+    
+    func setDelegate(delegate: WarpObserverDelegate) {
+        self.delegate = delegate
+    }
+    
+    func onConnectionSettingsChanged() async {
+        await restart()
+    }
+    
+    func restart() async {
+        
+        guard managerState != .restarting else { return }
+        managerState = .restarting
+        
+        // This operation will trigger a restart
+        warpState = .restarting
+
+        self.warp?.stop()
+        
+        self.warp = nil
+        
+        warpState = .notInitialized
+        
+        // Needed for iOS
+        endBackgroundTask()
+        
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        await start()
+    }
+    
+    private func startBackgroundTask() async {
+#if canImport(UIKit)
+        self.backgroundTaskId = await UIApplication.shared.beginBackgroundTask(withName: "WarpManager.start", expirationHandler: { [weak self] in
+            
+            let ref = self
+            
+            _ = Task.detached {
+                await ref?.shouldSuspend()
+            }
+            
+        })
+#endif
+    }
+    
+    private func endBackgroundTask() {
+#if canImport(UIKit)
+        let backgroundTaskId = self.backgroundTaskId
+        
+        if backgroundTaskId != .invalid {
+            Task.detached {
+                await UIApplication.shared.endBackgroundTask(backgroundTaskId)
+            }
+        }
+        self.backgroundTaskId = .invalid
+#endif
+    }
+}

--- a/Shared/Views/ContentView.swift
+++ b/Shared/Views/ContentView.swift
@@ -45,8 +45,6 @@ struct ContentView: View {
                 switch appState.state {
                 case .notInitialized:
                     ProgressView("Initializing...")
-                case .stopped:
-                    ProgressView("Stopped...")
                 case .restarting:
                     ProgressView("Restarting...")
                 case .failure(let warpError):

--- a/Shared/lib/NetworkUtils.swift
+++ b/Shared/lib/NetworkUtils.swift
@@ -8,6 +8,8 @@
 import Foundation
 import Network
 
+import os
+
 struct IFAddress {
     let interfaceName: String
     let ipAddress: IPAddress
@@ -54,3 +56,96 @@ func getIFAddresses() -> [IFAddress] {
     
     return addresses
 }
+
+
+func requestLocalNetworkPermissionAsync(timeout: Double) async -> Bool {
+    return await withCheckedContinuation { continuation in
+        DispatchQueue.global().async {
+            let hasPermission = requestLocalNetworkPermission(timeout: timeout)
+            continuation.resume(returning: hasPermission)
+        }
+    }
+}
+
+
+func requestLocalNetworkPermission(timeout: Double) -> Bool {
+    
+    var canDiscoverSelf = false
+    
+    let semaphore = DispatchSemaphore(value: 0)
+    
+    let browserParams = NWParameters()
+    browserParams.includePeerToPeer = false
+    
+    let browser = NWBrowser(for: .bonjourWithTXTRecord(type: "_warpinator._tcp", domain: nil), using: browserParams)
+    
+    browser.stateUpdateHandler = { newState in
+        
+        switch newState {
+        case .failed(_):
+            
+            // Signal that something failed and we can stop waiting
+            canDiscoverSelf = false
+            semaphore.signal()
+        default:
+            break
+        }
+    }
+    
+    browser.browseResultsChangedHandler = { results, changes in
+        if results.count >= 1 {
+            // Signal that we found a remote (probably ourselves) and can stop waiting
+            canDiscoverSelf = true
+            semaphore.signal()
+        }
+    }
+    
+    // Start browsing and ask for updates on a background queue.
+    browser.start(queue: .global())
+    
+    
+    let listenerParams = NWParameters.udp
+    listenerParams.includePeerToPeer = true
+    
+    let listener: NWListener
+    
+    do {
+        listener = try NWListener(using: listenerParams)
+    } catch {
+        os_log("Failed to create NWListener: \(error.localizedDescription)")
+        
+        return false
+    }
+        
+    listener.stateUpdateHandler = { newState in
+        switch newState {
+        case .ready:
+            break
+        case .failed(_):
+            // Signal that something failed and we can stop waiting
+            canDiscoverSelf = false
+            semaphore.signal()
+        default:
+            break
+        }
+    }
+    
+    listener.newConnectionHandler = { _ in }
+                
+    listener.service = NWListener.Service(name: "test service",
+                                          type: "_warpinator._tcp",
+                                          txtRecord: NWTXTRecord(["type": "flush"]))
+    
+    // Start listening, and request updates on a background queue.
+    listener.start(queue: .global())
+    
+    let _ = semaphore.wait(timeout: .now() + timeout)
+    
+    browser.cancel()
+    listener.cancel()
+    
+    return canDiscoverSelf
+}
+
+
+

--- a/Shared/warpinator_projectApp.swift
+++ b/Shared/warpinator_projectApp.swift
@@ -39,16 +39,15 @@ class AppState: ObservableObject, WarpObserverDelegate {
     func onScenePhaseChange(phase: ScenePhase) {
         switch(phase) {
         case .background:
-//            Task.detached {
-//                await self.warpManager.background()
-//            }
+            // Suspending is handled in WarpManager using beginBackgroundTask.
             return
         case .inactive:
-//            Task.detached {
-//                await self.warpManager.pause()
-//            }
+            // App is not visible to the user here. Could pause bonjour here, to let other remotes
+            // now that the app will suspend soon, but doesn't seem necessary as it is done just before suspending.
             return
         case .active:
+            // The app came into the foreground again. Need to call resume as the app might have suspended,
+            // after which a refresh of bonjour / restart of grpc servers is needed.
             Task.detached {
                 await self.warpManager.resume()
             }

--- a/warpinator-project.xcodeproj/project.pbxproj
+++ b/warpinator-project.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		4C195A8F2B931A4800E18958 /* AuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDD571227B9842600A9B537 /* AuthTests.swift */; };
 		4C195A922B931A4800E18958 /* helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA9E5C8281449460044CE1F /* helpers.swift */; };
 		4C21479227EB3E1700DF0302 /* DocumentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7E832927EB2ED400E393B5 /* DocumentPicker.swift */; };
+		4C3924EB2BA33A0B0046C923 /* WarpManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3924EA2BA33A0B0046C923 /* WarpManager.swift */; };
+		4C3924EC2BA33A0B0046C923 /* WarpManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3924EA2BA33A0B0046C923 /* WarpManager.swift */; };
 		4C39E80827E8C89F000F0ACD /* TransferOp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C39E80727E8C89F000F0ACD /* TransferOp.swift */; };
 		4C39E80927E8C89F000F0ACD /* TransferOp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C39E80727E8C89F000F0ACD /* TransferOp.swift */; };
 		4C3F86B527E7B0D900555A83 /* AuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDD571227B9842600A9B537 /* AuthTests.swift */; };
@@ -155,6 +157,7 @@
 /* Begin PBXFileReference section */
 		4C1443B627E7A2E600F87557 /* NetworkConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConfig.swift; sourceTree = "<group>"; };
 		4C195A982B931A4800E18958 /* Tests Shared (macOS).xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests Shared (macOS).xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C3924EA2BA33A0B0046C923 /* WarpManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarpManager.swift; sourceTree = "<group>"; };
 		4C39E80727E8C89F000F0ACD /* TransferOp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferOp.swift; sourceTree = "<group>"; };
 		4C3F86A927E7AFE000555A83 /* Tests Shared (iOS).xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests Shared (iOS).xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C3F86B627E7B87700555A83 /* NetworkUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkUtils.swift; sourceTree = "<group>"; };
@@ -382,6 +385,7 @@
 		4CDD56BF27B4105800A9B537 /* Backend */ = {
 			isa = PBXGroup;
 			children = (
+				4C3924EA2BA33A0B0046C923 /* WarpManager.swift */,
 				4CDD56EB27B79C2C00A9B537 /* WarpBackend.swift */,
 				4CA9E5BA280F10F40044CE1F /* model */,
 				4CDD56C027B4108F00A9B537 /* Auth.swift */,
@@ -730,6 +734,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C3924EB2BA33A0B0046C923 /* WarpManager.swift in Sources */,
 				4CDD56EC27B79C2C00A9B537 /* WarpBackend.swift in Sources */,
 				4CDD56C727B6672D00A9B537 /* BonjourDiscovery.swift in Sources */,
 				4CF735E029C76F220056FA45 /* LabeledHStack.swift in Sources */,
@@ -775,6 +780,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C3924EC2BA33A0B0046C923 /* WarpManager.swift in Sources */,
 				4CDD56ED27B79C2C00A9B537 /* WarpBackend.swift in Sources */,
 				4CDD56C827B6672D00A9B537 /* BonjourDiscovery.swift in Sources */,
 				4CF735E129C76F220056FA45 /* LabeledHStack.swift in Sources */,


### PR DESCRIPTION
This PR brings the following features:
- Added `WarpManager` to initialise and (re)start WarpBackend asynchronously
- `requestLocalNetworkPermission` method that checks if the user granted local network permission
  - iOS does not have an API for explicitly requesting/checking for local network permission
  - `requestLocalNetworkPermission` works by checking if a bonjour service can be discovered (on iOS)

Bug fixes (iOS):
- Fix freeze on first launch before local network permission was granted (#6)
  - Previously servers were launched before/during rendering the `ContentView` which froze the app when the user did not yet give local network permission
- Fix an issue that made prevented reconnecting to remotes when coming back to the foreground after suspending
  - Fixed by restarting the WarpBackend when becoming active after suspending, similarly to after a settings change

This PR supersedes #21.
Fixes #6 