### PR TITLE
Add port and auth port settings

### DIFF
--- a/Shared/Settings.swift
+++ b/Shared/Settings.swift
@@ -22,7 +22,7 @@ protocol WarpSettings {
 }
 
 enum WarpSettingsKey: String {
-    case port, authport, groupcode
+    case port, authPort, groupcode
 }
 
 extension WarpSettingsKey {
@@ -40,6 +40,8 @@ extension WarpSettingsKey {
 }
 
 class WarpSetingsUserDefaults: WarpSettings {
+    private static let defaultPort = 42000
+    private static let defaultAuthPort = 42001
     
     static var shared = WarpSetingsUserDefaults()
     
@@ -54,20 +56,39 @@ class WarpSetingsUserDefaults: WarpSettings {
         return WarpSetingsUserDefaults.getIdentity(hostName: NetworkConfig.shared.hostname)
     }
     
-    var port = 42000
-    var authPort = 42001
+    var port: Int {
+        get { return WarpSettingsKey.port.get(defaultValue: WarpSetingsUserDefaults.defaultPort) }
+        set {
+            WarpSettingsKey.port.set(newValue: newValue)
+            
+            signalConnectionSettingsChanged()
+        }
+    }
+    
+    var authPort: Int {
+        get { return WarpSettingsKey.authPort.get(defaultValue: WarpSetingsUserDefaults.defaultAuthPort) }
+        set {
+            WarpSettingsKey.authPort.set(newValue: newValue)
+            
+            signalConnectionSettingsChanged()
+        }
+    }
     
     var groupCode: String {
         get { return WarpSettingsKey.groupcode.get(defaultValue: DEFAULT_GROUP_CODE) }
         set {
             WarpSettingsKey.groupcode.set(newValue: newValue)
             
-            DispatchQueue.global().async {
-                self.connectionSettingsChangedCallbacks.forEach { $0() }
-            }
+            signalConnectionSettingsChanged()
         }
     }
 
+    private func signalConnectionSettingsChanged() {
+        DispatchQueue.global().async {
+            self.connectionSettingsChangedCallbacks.forEach { $0() }
+        }
+    }
+    
     
     static func getIdentity(hostName: String) -> String {
         

--- a/Shared/SettingsView.swift
+++ b/Shared/SettingsView.swift
@@ -37,11 +37,38 @@ struct SettingsView: View {
                     settings.groupCode = groupCodeText
                 })
             }
-
+            
+#if os(macOS)
+            Divider()
+                .padding(.vertical, 5.0)
+#endif
+            
+            Section(header: Text("Network ports")) {
+                LabeledHStack("Port") {
+                    TextField("Port", text: $portText)
+                }
+                
+                LabeledHStack("Auth port") {
+                    TextField("Auth port", text: $authPortText)
+                }
+                
+                Button("Set ports", action: {
+                    guard let port = Int(portText) else { return }
+                    guard let authPort = Int(authPortText) else { return }
+                    
+                    settings.port = port
+                    settings.authPort = authPort
+                })
+            }
         }
         .padding(20)
         .frame(width: 350)
     }
 }
 
-
+// Preview Provider
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView()
+    }
+}

--- a/Shared/SettingsView.swift
+++ b/Shared/SettingsView.swift
@@ -61,8 +61,6 @@ struct SettingsView: View {
                 })
             }
         }
-        .padding(20)
-        .frame(width: 350)
     }
 }
 

--- a/Shared/warpinator_projectApp.swift
+++ b/Shared/warpinator_projectApp.swift
@@ -95,6 +95,8 @@ struct warpinator_projectApp: App {
 #if os(macOS)
         Settings {
             SettingsView()
+                .padding(20)
+                .frame(width: 350)
         }
 #endif
     }


### PR DESCRIPTION
This PR adds the following features:
- Port and auth port setting fields (fixes #25).
- Upon setting them, the `WarpBackend` restarts with the new settings.

And fixes the following bug:
- On iOS, the settings sheet looked weird because of a frame and padding.
  - Fixed by only applying the frame and padding on macOS.