### PR TITLE
Improve UI for remote status

### DIFF
--- a/Shared/Views/RemoteDetailView.swift
+++ b/Shared/Views/RemoteDetailView.swift
@@ -89,6 +89,7 @@ struct RemoteDetailView: View {
                             showingSheet.toggle()
 #endif
                         }
+                        .disabled(viewModel.disableSendFileButton)
                     }
                 }
 #if !os(macOS)
@@ -208,6 +209,9 @@ extension RemoteDetailView {
         @Published
         var showStatusView: Bool = true
         
+        @Published
+        var disableSendFileButton: Bool = true
+        
         private let remote: RemoteProtocol
         
         private var tokens: Set<AnyCancellable> = .init()
@@ -243,6 +247,8 @@ extension RemoteDetailView {
                 remote.statePublisher().receive(on: DispatchQueue.main).sink { state in
                     self.stateDescription = state.description
                     self.state = state
+                    
+                    self.disableSendFileButton = state != .online
                                         
                     // If the new status is online, delay hiding the view for 1 second
                     let willBecomeHidden = self.showStatusView && state == .online

--- a/Shared/Views/RemoteDetailView.swift
+++ b/Shared/Views/RemoteDetailView.swift
@@ -24,10 +24,21 @@ struct RemoteDetailView: View {
     var viewModel: ViewModel
         
     @State
-    var showingSheet = false
+    var showingSheet: Bool
     
     @StateObject
     var layoutInfo = LayoutInfo()
+    
+    init(viewModel: ViewModel, showingSheet: Bool=false) {
+        self.viewModel = viewModel
+        self.showingSheet = showingSheet
+        
+#if canImport(UIKit)
+        // On iOS the title tends to get truncated.
+        // This sets a property of the underlying UILabel to  adjust the font size to fit.
+        UILabel.appearance(whenContainedInInstancesOf: [UINavigationBar.self]).adjustsFontSizeToFitWidth = true
+#endif
+    }
     
     var body: some View {
         GeometryReader {geom in
@@ -55,8 +66,15 @@ struct RemoteDetailView: View {
                 layoutInfo.width = geom.size.width
             }.onChange(of: geom.size) { newSize in
                 layoutInfo.width = newSize.width
-            }.navigationTitle("\(viewModel.title) (\(viewModel.state))")
-                .toolbar {
+            }
+            .navigationTitle(Text(viewModel.title))
+            
+#if canImport(UIKit)
+            .navigationBarTitleDisplayMode(.inline)
+#endif
+            
+            .toolbar {
+                    
                     ToolbarItem(placement: .primaryAction) {
                         Button("Send files") {
 #if os(macOS)

--- a/Shared/Views/RemoteDetailView.swift
+++ b/Shared/Views/RemoteDetailView.swift
@@ -243,8 +243,12 @@ extension RemoteDetailView {
                 remote.statePublisher().receive(on: DispatchQueue.main).sink { state in
                     self.stateDescription = state.description
                     self.state = state
-                    
-                    withAnimation {
+                                        
+                    // If the new status is online, delay hiding the view for 1 second
+                    let willBecomeHidden = self.showStatusView && state == .online
+                    let delayIfHiding = willBecomeHidden ? 1.0 : 0.0
+
+                    withAnimation(.default.delay(delayIfHiding)) {
                         self.showStatusView = self.state != .online
                     }
                 }.store(in: &tokens)


### PR DESCRIPTION
This PR addresses the following UI issues:
- Remote detail view navigation title often truncated on iOS (fixes #27)
  - The title now only contains the remote name
  - The remote status is in a separate status view that only appears when the remote is not online
  - The font size of the title adjusts to fit the title within the navigation bar

- The send files button is now disabled when the remote state is not offline
