### PR TITLE
Disable showing own remote

### DIFF
--- a/Shared/Backend/BonjourDiscovery.swift
+++ b/Shared/Backend/BonjourDiscovery.swift
@@ -88,8 +88,12 @@ class BonjourDiscovery: PeerDiscovery {
     private var listener: NWListener?
     private var browser: NWBrowser?
     
-    init(config: DiscoveryConfig) {
+    private let canDiscoverSelf: Bool
+    
+    init(config: DiscoveryConfig, canDiscoverSelf: Bool=true) {
         self.config = config
+        
+        self.canDiscoverSelf = canDiscoverSelf
     }
 
     
@@ -110,7 +114,7 @@ class BonjourDiscovery: PeerDiscovery {
     private func addOrUpdatePeer(peer: MDNSPeer) {
         if peer.txtRecord["type"] != "flush" {
             // Ignore own name (|| true is added for debugging to check if sending to self even works)
-            if peer.name != config.identity || true {
+            if peer.name != config.identity || self.canDiscoverSelf {
                 self.onRemotesChanged(.added(peer: peer))
             }
         }

--- a/Shared/Backend/WarpBackend.swift
+++ b/Shared/Backend/WarpBackend.swift
@@ -37,7 +37,7 @@ class WarpBackend {
         
         let discoveryConfig = DiscoveryConfig(identity: auth.identity, api_version: "2", auth_port: settings.authPort, hostname: networkConfig.hostname)
 
-        self.discovery = BonjourDiscovery(config: discoveryConfig)
+        self.discovery = BonjourDiscovery(config: discoveryConfig, canDiscoverSelf: settings.canDiscoverSelf)
         
         self.remoteRegistration = RemoteRegistration(discovery: discovery, auth: auth, clientEventLoopGroup: eventLoopGroup)
     }

--- a/Shared/Settings.swift
+++ b/Shared/Settings.swift
@@ -18,11 +18,13 @@ protocol WarpSettings {
     
     var groupCode: String { get }
     
+    var canDiscoverSelf: Bool { get }
+    
     func addOnConnectionSettingsChangedCallback(_: @escaping () -> Void)
 }
 
 enum WarpSettingsKey: String {
-    case port, authPort, groupcode
+    case port, authPort, groupcode, canDiscoverSelf
 }
 
 extension WarpSettingsKey {
@@ -84,6 +86,17 @@ class WarpSetingsUserDefaults: WarpSettings, ObservableObject {
             objectWillChange.send()
             
             WarpSettingsKey.groupcode.set(newValue: newValue)
+            
+            signalConnectionSettingsChanged()
+        }
+    }
+    
+    var canDiscoverSelf: Bool {
+        get { return WarpSettingsKey.canDiscoverSelf.get(defaultValue: false) }
+        set {
+            objectWillChange.send()
+            
+            WarpSettingsKey.canDiscoverSelf.set(newValue: newValue)
             
             signalConnectionSettingsChanged()
         }

--- a/Shared/Settings.swift
+++ b/Shared/Settings.swift
@@ -16,7 +16,7 @@ protocol WarpSettings {
     var port: Int { get }
     var authPort: Int { get }
     
-    var groupCode: String { get set }
+    var groupCode: String { get }
     
     func addOnConnectionSettingsChangedCallback(_: @escaping () -> Void)
 }
@@ -39,7 +39,7 @@ extension WarpSettingsKey {
     }
 }
 
-class WarpSetingsUserDefaults: WarpSettings {
+class WarpSetingsUserDefaults: WarpSettings, ObservableObject {
     private static let defaultPort = 42000
     private static let defaultAuthPort = 42001
     
@@ -59,6 +59,8 @@ class WarpSetingsUserDefaults: WarpSettings {
     var port: Int {
         get { return WarpSettingsKey.port.get(defaultValue: WarpSetingsUserDefaults.defaultPort) }
         set {
+            objectWillChange.send()
+            
             WarpSettingsKey.port.set(newValue: newValue)
             
             signalConnectionSettingsChanged()
@@ -68,6 +70,8 @@ class WarpSetingsUserDefaults: WarpSettings {
     var authPort: Int {
         get { return WarpSettingsKey.authPort.get(defaultValue: WarpSetingsUserDefaults.defaultAuthPort) }
         set {
+            objectWillChange.send()
+            
             WarpSettingsKey.authPort.set(newValue: newValue)
             
             signalConnectionSettingsChanged()
@@ -77,6 +81,8 @@ class WarpSetingsUserDefaults: WarpSettings {
     var groupCode: String {
         get { return WarpSettingsKey.groupcode.get(defaultValue: DEFAULT_GROUP_CODE) }
         set {
+            objectWillChange.send()
+            
             WarpSettingsKey.groupcode.set(newValue: newValue)
             
             signalConnectionSettingsChanged()

--- a/Shared/SettingsView.swift
+++ b/Shared/SettingsView.swift
@@ -56,6 +56,19 @@ struct SettingsView: View {
                     settings.authPort = authPort
                 })
             }
+            
+#if os(macOS)
+            Divider()
+                .padding(.vertical, 5.0)
+#endif
+
+            Section(header: Text("Debug settings")) {
+                Toggle("Allow connecting to self", isOn: .init(get: {
+                    settings.canDiscoverSelf
+                }, set: { canDiscoverSelf in
+                    settings.canDiscoverSelf = canDiscoverSelf
+                }))
+            }
         }
         .onAppear {
             portText = String(settings.port)

--- a/Shared/SettingsView.swift
+++ b/Shared/SettingsView.swift
@@ -9,20 +9,16 @@ import SwiftUI
 
 struct SettingsView: View {
     
+    @ObservedObject
     var settings: WarpSetingsUserDefaults
         
-    @State var portText: String
-    @State var authPortText: String
+    @State var portText: String = ""
+    @State var authPortText: String = ""
 
-    @State var groupCodeText: String
+    @State var groupCodeText: String = ""
     
     init() {
         settings = .shared
-        
-        portText = String(settings.port)
-        authPortText = String(settings.authPort)
-        
-        groupCodeText = String(settings.groupCode)
     }
     
     var body: some View {
@@ -60,6 +56,12 @@ struct SettingsView: View {
                     settings.authPort = authPort
                 })
             }
+        }
+        .onAppear {
+            portText = String(settings.port)
+            authPortText = String(settings.authPort)
+            
+            groupCodeText = String(settings.groupCode)
         }
     }
 }


### PR DESCRIPTION
Currently, the own device shows up in the list of remotes, and files can be sent to itself. This is nice for debugging, but not useful.

This PR makes the following changes:
- Disable discovering remotes with the same mDNS name as the device itself.
- Adding a debug settings option to enable discovering own device as remote.
- Refactor `Settings` to conform to `ObservableObject` to support a toggle button setting.