### PR TITLE
Fix TransferOp state

### DIFF
--- a/Shared/Backend/Remote.swift
+++ b/Shared/Backend/Remote.swift
@@ -444,6 +444,9 @@ class Remote: FullRemoteProtocol, ObservableObject {
     
     private func receiveChunks(transferOp: TransferOp, downloader: TransferDownloader, response: GRPCAsyncResponseStream<FileChunk>) async throws {
         for try await chunk in response {
+            guard transferOp.state == .started else {
+                throw TransferOpError.invalidStateWhileDownloading
+            }
             
             // Increment the progress metric
             Task {

--- a/Shared/Backend/Remote.swift
+++ b/Shared/Backend/Remote.swift
@@ -49,8 +49,19 @@ protocol RemoteProtocol {
     
 }
 
+protocol TransferCapabilities: AnyObject {
+    var transfersToRemote: Dictionary<UInt64, TransferToRemote>  { get set }
+    var transfersFromRemote: Dictionary<UInt64, TransferFromRemote> { get set }
 
-class Remote: RemoteProtocol, ObservableObject {
+    func cancelTransferOpRequest(timestamp: UInt64) async throws
+    func stopTransfer(timestamp: UInt64, error: Bool) async throws
+    func startTransfer(transferOp: TransferFromRemote, downloader: TransferDownloader) async throws
+}
+
+// For allowing Remote to be Mocked, extract into a seperate protocol
+typealias FullRemoteProtocol = RemoteProtocol & TransferCapabilities
+
+class Remote: FullRemoteProtocol, ObservableObject {
     
     private let statemachine: StateMachine
     private var stateCancellable: AnyCancellable?

--- a/Shared/Backend/TransferOp.swift
+++ b/Shared/Backend/TransferOp.swift
@@ -25,6 +25,7 @@ enum Direction {
 
 enum TransferOpError: Error {
     case invalidStateToStartTransfer
+    case invalidStateWhileDownloading
 }
 
 enum TransferOpEvent {

--- a/Shared/Backend/WarpServerProvider.swift
+++ b/Shared/Backend/WarpServerProvider.swift
@@ -131,6 +131,8 @@ class WarpServerProvider: WarpAsyncProvider {
             transferOp.tryEvent(event: .completed)
             
             print("\n\nWarpServerProvider: done sending chunks!")
+        } catch is CancellationError {
+            transferOp.tryEvent(event: .failure(reason: "Transfer was interrupted"))
         } catch {
             transferOp.tryEvent(event: .failure(reason: error.localizedDescription))
         }

--- a/Shared/FileProvider.swift
+++ b/Shared/FileProvider.swift
@@ -99,7 +99,9 @@ struct FileChunkSequence : Sequence {
             
             // Check if async iterator was canceled
             if Task.isCancelled {
-                return nil
+                
+                // Propagate Task cancellation
+                return .failure(CancellationError())
             }
                         
             // Try to get chunk iterator for next file
@@ -113,6 +115,8 @@ struct FileChunkSequence : Sequence {
                 }
             }
             
+            
+            // Finished iterating
             guard let currentFileChunkIterator = currentFileChunkIterator else {
                 return nil
             }

--- a/Shared/Views/TransferOpView.swift
+++ b/Shared/Views/TransferOpView.swift
@@ -384,6 +384,10 @@ extension TransferOpView {
 #if DEBUG
 
 class DummyTransferOp: TransferOpFromRemote {
+    func tryEvent(event: TransferOpEvent) {
+        
+    }
+    
     func checkIfWillOverwrite() -> Bool {
         willOverwrite
     }

--- a/warpinator-project.xcodeproj/project.pbxproj
+++ b/warpinator-project.xcodeproj/project.pbxproj
@@ -15,6 +15,11 @@
 		4C195A8F2B931A4800E18958 /* AuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDD571227B9842600A9B537 /* AuthTests.swift */; };
 		4C195A922B931A4800E18958 /* helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA9E5C8281449460044CE1F /* helpers.swift */; };
 		4C21479227EB3E1700DF0302 /* DocumentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7E832927EB2ED400E393B5 /* DocumentPicker.swift */; };
+		4C3507D72BD7E2B600FB150F /* TransferOpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3507D62BD7E2B600FB150F /* TransferOpTests.swift */; };
+		4C3507D82BD7F5F000FB150F /* TransferOpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3507D62BD7E2B600FB150F /* TransferOpTests.swift */; };
+		4C3507DA2BD7FF8100FB150F /* MockRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3507D92BD7FF8100FB150F /* MockRemote.swift */; };
+		4C3507DC2BD7FF8100FB150F /* MockRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3507D92BD7FF8100FB150F /* MockRemote.swift */; };
+		4C3507DD2BD803BA00FB150F /* MockRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3507D92BD7FF8100FB150F /* MockRemote.swift */; };
 		4C3924EB2BA33A0B0046C923 /* WarpManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3924EA2BA33A0B0046C923 /* WarpManager.swift */; };
 		4C3924EC2BA33A0B0046C923 /* WarpManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3924EA2BA33A0B0046C923 /* WarpManager.swift */; };
 		4C39E80827E8C89F000F0ACD /* TransferOp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C39E80727E8C89F000F0ACD /* TransferOp.swift */; };
@@ -157,6 +162,8 @@
 /* Begin PBXFileReference section */
 		4C1443B627E7A2E600F87557 /* NetworkConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConfig.swift; sourceTree = "<group>"; };
 		4C195A982B931A4800E18958 /* Tests Shared (macOS).xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests Shared (macOS).xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C3507D62BD7E2B600FB150F /* TransferOpTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferOpTests.swift; sourceTree = "<group>"; };
+		4C3507D92BD7FF8100FB150F /* MockRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemote.swift; sourceTree = "<group>"; };
 		4C3924EA2BA33A0B0046C923 /* WarpManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarpManager.swift; sourceTree = "<group>"; };
 		4C39E80727E8C89F000F0ACD /* TransferOp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferOp.swift; sourceTree = "<group>"; };
 		4C3F86A927E7AFE000555A83 /* Tests Shared (iOS).xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests Shared (iOS).xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -447,6 +454,8 @@
 				4CDD571227B9842600A9B537 /* AuthTests.swift */,
 				4CA9E5C8281449460044CE1F /* helpers.swift */,
 				4C5C7EF12846764E0063BE6F /* TransferDownloaderTests.swift */,
+				4C3507D62BD7E2B600FB150F /* TransferOpTests.swift */,
+				4C3507D92BD7FF8100FB150F /* MockRemote.swift */,
 			);
 			path = "warpinator-projectTests";
 			sourceTree = "<group>";
@@ -714,6 +723,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C3507DD2BD803BA00FB150F /* MockRemote.swift in Sources */,
+				4C3507D82BD7F5F000FB150F /* TransferOpTests.swift in Sources */,
 				4C195A8E2B931A4800E18958 /* TransferDownloaderTests.swift in Sources */,
 				4C195A8F2B931A4800E18958 /* AuthTests.swift in Sources */,
 				4C195A922B931A4800E18958 /* helpers.swift in Sources */,
@@ -827,6 +838,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C4A739E27B3D2D6004EDA61 /* Tests_iOSLaunchTests.swift in Sources */,
+				4C3507DA2BD7FF8100FB150F /* MockRemote.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -843,6 +855,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C5C7EF22846764E0063BE6F /* TransferDownloaderTests.swift in Sources */,
+				4C3507D72BD7E2B600FB150F /* TransferOpTests.swift in Sources */,
+				4C3507DC2BD7FF8100FB150F /* MockRemote.swift in Sources */,
 				4CDD571327B9842600A9B537 /* AuthTests.swift in Sources */,
 				4CA9E5C9281449460044CE1F /* helpers.swift in Sources */,
 			);

--- a/warpinator-projectTests/MockRemote.swift
+++ b/warpinator-projectTests/MockRemote.swift
@@ -1,0 +1,79 @@
+//
+//  MockRemote.swift
+//  warpinator-project
+//
+//  Created by Emanuel on 23/04/2024.
+//
+
+import Foundation
+
+import Combine
+
+@testable import warpinator_project
+
+
+enum MockError: Error {
+    case notImplemented
+}
+
+class MockRemote: FullRemoteProtocol {
+    var peer: Peer
+    
+    var transfers: CurrentValueSubject<Array<TransferOp>, Never>
+    
+    var transfersToRemote: Dictionary<UInt64, TransferToRemote>
+    
+    var transfersFromRemote: Dictionary<UInt64, TransferFromRemote>
+    
+    var state: RemoteState = .online
+    
+    init(peer: Peer, transfersToRemote: Dictionary<UInt64, TransferToRemote> = [:], transfersFromRemote: Dictionary<UInt64, TransferFromRemote> = [:], state: RemoteState = .online) {
+        self.peer = peer
+        self.transfers = .init([])
+        self.transfersToRemote = transfersToRemote
+        self.transfersFromRemote = transfersFromRemote
+        self.state = state
+    }
+    
+    func ping() async throws {
+        return
+    }
+    
+    func requestTransfer(url: URL) async throws {
+        throw MockError.notImplemented
+    }
+    
+    func statePublisher() -> AnyPublisher<RemoteState, Never> {
+        preconditionFailure("Not implemented")
+    }
+        
+    func cancelTransferOpRequest(timestamp: UInt64) async throws {
+        throw MockError.notImplemented
+    }
+    
+    func stopTransfer(timestamp: UInt64, error: Bool) async throws {
+        throw MockError.notImplemented
+    }
+    
+    func startTransfer(transferOp: TransferFromRemote, downloader: TransferDownloader) async throws {
+        throw MockError.notImplemented
+    }
+    
+    
+}
+
+/// A mock `Peer` implementation with fixed resolve() values.
+struct TestPeer: Peer {
+    
+    var name: String
+    
+    var hostName: String
+    
+    var fetchCertInfo: FetchCertInfo?
+    
+    let resolveResult: (String, Int)
+    
+    func resolve() async throws -> (String, Int) {
+        return resolveResult
+    }
+}

--- a/warpinator-projectTests/TransferOpTests.swift
+++ b/warpinator-projectTests/TransferOpTests.swift
@@ -1,0 +1,116 @@
+//
+//  TransferOpStateTests.swift
+//  warpinator-projectTests
+//
+//  Created by Emanuel on 23/04/2024.
+//
+
+import Foundation
+
+import XCTest
+@testable import warpinator_project
+
+class TransferOpTests: XCTestCase {
+    var transferOpFromRemote: TransferOp!
+    
+    var peer: Peer!
+    var remote: Remote!
+
+    override func setUp() {
+        super.setUp()
+        
+        peer = TestPeer(name: "some-peer-name", hostName: "peer.local", resolveResult: ("0.1.2.3", 42000))
+                
+        let remote = MockRemote(peer: peer)
+        
+        transferOpFromRemote = TransferFromRemote(timestamp: 12345,
+                                        title: "warpinator-project.app.dSYM.zip",
+                                        mimeType: "archive/zip",
+                                        size: 1430000,
+                                        count: 1,
+                                        topDirBasenames: ["warpinator-project.app.dSYM.zip"],
+                                        initialState: .requested,
+                                        remote: remote
+        )
+    }
+
+    override func tearDown() {
+        transferOpFromRemote = nil
+        super.tearDown()
+    }
+        
+    func testValidTransitionToStarted() {
+        transferOpFromRemote.tryEvent(event: .start)
+        XCTAssertEqual(transferOpFromRemote.state, .started, "The state should transition to started from requested")
+    }
+    
+    func testCancellationFromRequestedState() {
+        // Should be ignored
+        transferOpFromRemote.tryEvent(event: .requested)
+        transferOpFromRemote.tryEvent(event: .cancelledByUser)
+        XCTAssertEqual(transferOpFromRemote.state, .requestCanceled, "The state should transition to requestCanceled from requested")
+    }
+    
+    func testTransitionToFailureWithErrorMessage() {
+        transferOpFromRemote.tryEvent(event: .start)
+        
+        let failureReason = "Network Error"
+        
+        transferOpFromRemote.tryEvent(event: .failure(reason: failureReason))
+        
+        transferOpFromRemote.tryEvent(event: .completed)
+        
+        XCTAssertNotEqual(transferOpFromRemote.state, .completed, "The state should not transition to completed after a failure")
+        
+        guard case .failed(let reason) = transferOpFromRemote.state else {
+            return XCTFail("State should be .failed")
+        }
+        
+        XCTAssertEqual(reason, failureReason, "The state should include the failure reason")
+    }
+    
+    func testNoTransitionForInvalidEvent() {
+        let initialState = transferOpFromRemote.state
+        transferOpFromRemote.tryEvent(event: .completed)
+                
+        XCTAssertEqual(transferOpFromRemote.state, initialState, "The state should not change on an invalid event")
+    }
+    
+    func testStateShouldStayCancelledAfterFailure() {
+        transferOpFromRemote.tryEvent(event: .requested)
+        transferOpFromRemote.tryEvent(event: .requestCancelledByRemote)
+        transferOpFromRemote.tryEvent(event: .failure(reason: "some failure"))
+                
+        XCTAssertEqual(transferOpFromRemote.state, .requestCanceled, "The state should stay on cancelled")
+    }
+    
+    func testCanCancelAfterCompletion() {
+        // This is the expected behaviour, because one of the remotes might cancel just before completing the transfer, and then the other one should also cancel.
+        
+        transferOpFromRemote.tryEvent(event: .start)
+        transferOpFromRemote.tryEvent(event: .completed)
+
+        transferOpFromRemote.tryEvent(event: .transferCancelledByRemote)
+        
+        XCTAssertEqual(transferOpFromRemote.state, .transferCanceled, "The state should become canceled even when canceling after completing")
+    }
+    
+    func testShouldNotCompleteAfterCancelled() {
+        transferOpFromRemote.tryEvent(event: .start)
+        transferOpFromRemote.tryEvent(event: .transferCancelledByRemote)
+
+        transferOpFromRemote.tryEvent(event: .completed)
+        
+        XCTAssertEqual(transferOpFromRemote.state, .transferCanceled, "The state should not become complete after cancellation")
+    }
+
+    
+    func testStateShouldReflectLastFailure() {
+        transferOpFromRemote.tryEvent(event: .start)
+        transferOpFromRemote.tryEvent(event: .failure(reason: "some failure"))
+        
+        transferOpFromRemote.tryEvent(event: .failure(reason: "some other failure"))
+
+        XCTAssertEqual(transferOpFromRemote.state, .failed(reason: "some other failure"), "The state should reflect the last failure")
+    }
+}


### PR DESCRIPTION
Fixes #16 

The transfer operation state previously was not always accurate, for instance it could become complete after cancellation.

This PR contains multiple improvements to the state management of TransferOp:
- Explicit `tryEvent` state machine, ignoring events that do not make sense.
  - For example, if the state is cancelled and then a failure occurs, the state should stay cancelled.
- Fixed: state should be failure after remote machine gets disconnected while sending chunks.
- Fixed: on cancellation should stop receiving new chunks.


Testing:
- Factored out `FullRemoteProtocol` to allow mocking `Remote`
- Added unit tests for `TransferOp.tryEvent` with mocked `MockRemote`